### PR TITLE
Create ChallengeAdvisor skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.11
+
+COPY backend/requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY backend ./backend
+
+CMD ["backend.main.handler"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# python-code-advisor
+# Challenge Advisor
+
+Skeleton project for automated feedback system.
+
+## Amplify Setup (comments)
+```
+# Install amplify CLI if not already installed
+npm install -g @aws-amplify/cli
+
+# Initialize amplify project
+amplify init
+
+# Add API endpoint (REST)
+amplify add api
+
+# Add hosting configuration
+amplify add hosting
+
+# Publish to Amplify
+amplify publish
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,65 @@
+import os
+import json
+import boto3
+from fastapi import FastAPI, HTTPException
+from mangum import Mangum
+from uuid import uuid4
+from run_code import run_in_docker
+
+app = FastAPI()
+
+dynamodb = boto3.resource("dynamodb", region_name=os.getenv("AWS_REGION", "us-east-1"))
+challenges_table = dynamodb.Table(os.getenv("CHALLENGES_TABLE", "Challenges"))
+submissions_table = dynamodb.Table(os.getenv("SUBMISSIONS_TABLE", "Submissions"))
+
+bedrock = boto3.client("bedrock-runtime", region_name=os.getenv("AWS_REGION", "us-east-1"))
+
+PROMPT_TEMPLATE = """
+あなたの役割はPython課題のアドバイザーです。
+テスト結果:
+{test_result}
+
+よくあるミス:
+{common_mistakes}
+
+決して正解コードを教えないでください。以下の観点でフィードバックを生成してください。
+- エラー原因の候補
+- ロジックチェックと改善ヒント
+- コード品質と可読性向上の提案
+- パフォーマンス改善案
+- 学習に役立つリンク
+- モチベーションを維持するためのメッセージ
+"""
+
+@app.post("/submit-code")
+async def submit_code(payload: dict):
+    code = payload.get("code")
+    challenge_id = payload.get("challenge_id")
+    if not code or not challenge_id:
+        raise HTTPException(status_code=400, detail="code and challenge_id required")
+
+    result = run_in_docker(code)
+
+    prompt = PROMPT_TEMPLATE.format(
+        test_result=json.dumps(result, ensure_ascii=False),
+        common_mistakes="登録されたよくあるミスをここに挿入"
+    )
+
+    response = bedrock.invoke_model(
+        modelId=os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-v2"),
+        body=json.dumps({"prompt": prompt})
+    )
+    body = json.loads(response.get("body", "{}"))
+    feedback = body.get("completion", "")
+
+    submissions_table.put_item(Item={
+        "submission_id": str(uuid4()),
+        "challenge_id": challenge_id,
+        "code": code,
+        "result": result,
+        "feedback": feedback
+    })
+
+    return {"feedback": feedback, "result": result}
+
+handler = Mangum(app)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+mangum
+boto3

--- a/backend/run_code.py
+++ b/backend/run_code.py
@@ -1,0 +1,28 @@
+import subprocess
+import tempfile
+import os
+
+
+def run_in_docker(code: str):
+    tmpdir = tempfile.mkdtemp()
+    code_path = os.path.join(tmpdir, "main.py")
+    with open(code_path, "w") as f:
+        f.write(code)
+
+    cmd = [
+        "docker", "run", "--rm",
+        "--cpus", "0.5",
+        "--memory", "128m",
+        "-v", f"{tmpdir}:/app",
+        "python:3.11-slim",
+        "python", "/app/main.py"
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        return {
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "returncode": proc.returncode,
+        }
+    except subprocess.TimeoutExpired:
+        return {"stdout": "", "stderr": "Execution timed out", "returncode": -1}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import CodeForm from './components/CodeForm';
+import FeedbackView from './components/FeedbackView';
+import './index.css';
+
+export default function App() {
+  const [feedback, setFeedback] = useState(null);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Challenge Advisor</h1>
+      <CodeForm onResult={setFeedback} />
+      {feedback && <FeedbackView feedback={feedback} />}
+    </div>
+  );
+}

--- a/frontend/src/components/CodeForm.jsx
+++ b/frontend/src/components/CodeForm.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function CodeForm({ onResult }) {
+  const [code, setCode] = useState('');
+  const [challengeId, setChallengeId] = useState('');
+
+  const submit = async () => {
+    const res = await axios.post('/submit-code', {
+      code,
+      challenge_id: challengeId,
+    });
+    onResult(res.data.feedback);
+  };
+
+  return (
+    <div className="mb-4">
+      <input
+        className="border p-2 mb-2 w-full"
+        placeholder="Challenge ID"
+        value={challengeId}
+        onChange={(e) => setChallengeId(e.target.value)}
+      />
+      <textarea
+        className="border p-2 w-full"
+        rows={10}
+        placeholder="Paste your Python code here"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+      />
+      <button className="bg-blue-500 text-white px-4 py-2 mt-2" onClick={submit}>
+        Submit
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/FeedbackView.jsx
+++ b/frontend/src/components/FeedbackView.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FeedbackView({ feedback }) {
+  return (
+    <div className="bg-gray-100 p-4 rounded">
+      <h2 className="text-xl font-semibold mb-2">Feedback</h2>
+      <pre className="whitespace-pre-wrap">{feedback}</pre>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/infra/serverless.yml
+++ b/infra/serverless.yml
@@ -1,0 +1,76 @@
+service: challenge-advisor
+
+provider:
+  name: aws
+  runtime: python3.11
+  region: ap-northeast-1
+  environment:
+    CHALLENGES_TABLE: ${self:service}-Challenges
+    SUBMISSIONS_TABLE: ${self:service}-Submissions
+    BEDROCK_MODEL_ID: anthropic.claude-v2
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - dynamodb:PutItem
+        - dynamodb:GetItem
+        - dynamodb:Query
+      Resource: arn:aws:dynamodb:*:*:table/${self:provider.environment.CHALLENGES_TABLE}
+    - Effect: Allow
+      Action:
+        - dynamodb:PutItem
+        - dynamodb:GetItem
+        - dynamodb:Query
+      Resource: arn:aws:dynamodb:*:*:table/${self:provider.environment.SUBMISSIONS_TABLE}
+    - Effect: Allow
+      Action:
+        - "bedrock:*"
+      Resource: "*"
+plugins:
+  - serverless-offline
+  - serverless-dynamodb-local
+custom:
+  dynamodb:
+    stages:
+      - dev
+    start:
+      migrate: true
+functions:
+  api:
+    handler: backend/main.handler
+    events:
+      - httpApi:
+          path: /submit-code
+          method: post
+resources:
+  Resources:
+    ChallengesTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.CHALLENGES_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: challenge_id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: challenge_id
+            KeyType: HASH
+    SubmissionsTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.SUBMISSIONS_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: submission_id
+            AttributeType: S
+          - AttributeName: challenge_id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: submission_id
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: challenge_id-index
+            KeySchema:
+              - AttributeName: challenge_id
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL


### PR DESCRIPTION
## Summary
- add backend FastAPI lambda and code runner
- set up serverless config for API and DynamoDB tables
- add Dockerfile for Lambda container
- create simple React frontend with Tailwind
- add Amplify setup notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd4b4eb3483258bfb76aa37791a11